### PR TITLE
Allow for configuring the version name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This flow assumes auto-generated release notes will include JIRA issue keys. Thi
 
 |Input|Description|Example|
 |---|---|---|
+|`version_name`|Name of the version to create|${{ github.ref_name }}|
 |`jira_server`|JIRA server URL.|`https://company.atlassian.net`|
 |`jira_project`|JIRA project key.|`PRJ`|
 |`jira_user`|JIRA user with project admin permission.|`apiuser@company.com`|
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: Medsien/release-to-jira@main
         with:
+          version_name: prefix-${{ github.ref_name }}
           jira_server: 'https://company.atlassian.net'
           jira_project: 'PRJ'
           jira_user: 'user@company.com'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   jira_token:
     description: JIRA user token
     required: true
+  version_name:
+    description: The name of the version
+    required: true
 runs:
   using: composite
   steps:
@@ -41,6 +44,7 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
+        INPUT_VERSION_NAME: ${{ inputs.version_name }} 
         INPUT_JIRA_SERVER: ${{ inputs.jira_server }}
         INPUT_JIRA_PROJECT: ${{ inputs.jira_project }}
         INPUT_JIRA_USER: ${{ inputs.jira_user }}

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from pprint import pprint
 from jira_api import add_release_to_issue, get_or_create_release
 from notes_parser import extract_changes, extract_issue_id
 
-release_name = os.environ["GITHUB_REF_NAME"]
+release_name = os.environ["INPUT_VERSION_NAME"]
 release = get_or_create_release(release_name)
 print("JIRA Release:")
 pprint(release)


### PR DESCRIPTION
In cases where there are different releasable entities tracked in one Jira Project, it might be the case that tags in a GitHub repo follow semantic versioning but the versions should not clash in the Jira Project